### PR TITLE
feat: Implement user profile and organizational feedback API

### DIFF
--- a/core/api_permissions.py
+++ b/core/api_permissions.py
@@ -1,7 +1,17 @@
 # core/api_permissions.py
 
 from rest_framework import permissions
+from rest_framework.permissions import BasePermission, SAFE_METHODS
 
+class IsAuthorOrReadOnly(BasePermission):
+    """
+    Allows full access if the request user is the author of the object.
+    Otherwise, allows read-only access (GET, HEAD, OPTIONS).
+    """
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+        return obj.author == request.user
 
 class IsOwnerOrReadOnly(permissions.BasePermission):
     """

--- a/core/api_urls.py
+++ b/core/api_urls.py
@@ -13,11 +13,12 @@ from .api_views import (
     PrivateNoteViewSet, IdeaCategoryViewSet, IdeaViewSet, DashboardViewSet,
     RiskFlagViewSet, EmployeeRiskAnalysisViewSet, PsychologicalRiskSurveyViewSet,
     PsychologicalRiskResponseViewSet, AIRiskDetectionViewSet, StatisticalAnomalyViewSet,
-    StrategicHRPlanningViewSet, TranslationAPIView
+    StrategicHRPlanningViewSet, TranslationAPIView, OrganizationalFeedbackViewSet
 )
 
 # Router yaradılması
 router = DefaultRouter()
+router.register(r'organizational-feedback', OrganizationalFeedbackViewSet, basename='organizational-feedback')
 
 # ViewSet-ləri router-a qoşmaq
 router.register(r'users', IshchiViewSet)

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -1068,6 +1068,31 @@ class StatisticalAnomalyViewSet(viewsets.ViewSet):
 
 # === STRATEJİ KADR PLANLAŞDIRMASI API VİEWS ===
 
+from .models import OrganizationalFeedback
+from .serializers import OrganizationalFeedbackSerializer
+from .api_permissions import IsAuthorOrReadOnly
+
+class OrganizationalFeedbackViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint for creating, reading, updating, and deleting Organizational Feedback.
+    """
+    serializer_class = OrganizationalFeedbackSerializer
+    permission_classes = [IsAuthenticated, IsAuthorOrReadOnly]
+
+    def get_queryset(self):
+        """
+        This queryset is filtered to only return top-level feedback (not replies).
+        Replies will be nested inside their parents by the serializer.
+        """
+        return OrganizationalFeedback.objects.filter(parent=None)
+
+    def perform_create(self, serializer):
+        """
+        This hook is called when a new object is created. We use it to automatically
+        set the 'author' to the currently logged-in user.
+        """
+        serializer.save(author=self.request.user)
+
 class StrategicHRPlanningViewSet(viewsets.ViewSet):
     """Strateji HR planlaşdırma əməliyyatları"""
     permission_classes = [IsAuthenticated]

--- a/core/forms.py
+++ b/core/forms.py
@@ -570,25 +570,25 @@ class QeydiyyatFormu(UserCreationForm):
         )
 
 
+from .models import UserProfile
 class ProfileUpdateForm(forms.ModelForm):
     """İstifadəçi profil yeniləmə forması"""
     
     class Meta:
-        model = Ishchi
+        model = UserProfile
         fields = [
-            'first_name', 'last_name', 'email', 'elaqe_nomresi', 
-            'dogum_tarixi', 'profil_sekli'
+            'profil_sekli', 'bio', 'skills', 'interests', 'social_links', 'work_experience'
         ]
         widgets = {
-            'first_name': ModernTextInput(placeholder="Adınız"),
-            'last_name': ModernTextInput(placeholder="Soyadınız"),
-            'email': ModernEmailInput(),
-            'elaqe_nomresi': ModernTextInput(placeholder="+994 XX XXX XX XX"),
-            'dogum_tarixi': ModernDateInput(),
             'profil_sekli': forms.FileInput(attrs={
                 'class': 'form-control',
                 'accept': 'image/*'
-            })
+            }),
+            'bio': ModernTextarea(placeholder="Bio"),
+            'skills': ModernTextarea(placeholder="Skills"),
+            'interests': ModernTextarea(placeholder="Interests"),
+            'social_links': ModernTextInput(placeholder="Social Links"),
+            'work_experience': ModernTextarea(placeholder="Work Experience"),
         }
     
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This commit introduces the following features:
- A detailed user profile with skills, interests, social links, and work experience.
- An organizational feedback system with anonymity and threaded replies.

The changes include:
- Updated models: `UserProfile` and `OrganizationalFeedback`.
- Custom permission: `IsAuthorOrReadOnly`.
- New serializers: `UserProfileSerializer` and `OrganizationalFeedbackSerializer`.
- Updated serializer: `UserSerializer`.
- New viewset: `OrganizationalFeedbackViewSet`.
- Registered the new viewset in the API URLs.